### PR TITLE
Fix trail sticking when window loses focus

### DIFF
--- a/public/shaders/cursor_blaze.glsl
+++ b/public/shaders/cursor_blaze.glsl
@@ -97,6 +97,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord)
     float sdfTrail = getSdfParallelogram(vu, v0, v1, v2, v3);
 
     float progress = clamp((iTime - iTimeCursorChange) / DURATION, 0.0, 1.0);
+    progress = mix(1.0, progress, float(iFocus)); // when unfocused iTime stops, force trail done
     float easedProgress = ease(progress);
     // Distance between cursors determine the total length of the parallelogram;
     float lineLength = distance(centerCC, centerCP);

--- a/public/shaders/cursor_blaze_tapered.glsl
+++ b/public/shaders/cursor_blaze_tapered.glsl
@@ -101,6 +101,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord)
     float sdfTrail = getSdfParallelogram(vu, v0, v1, v2, v3);
 
     float progress = clamp((iTime - iTimeCursorChange) / DURATION, 0.0, 1.0);
+    progress = mix(1.0, progress, float(iFocus)); // when unfocused iTime stops, force trail done
     float easedProgress = ease(progress);
     // Distance between cursors determine the total length of the parallelogram;
     float lineLength = distance(centerCC, centerCP);

--- a/public/shaders/cursor_smear.glsl
+++ b/public/shaders/cursor_smear.glsl
@@ -101,6 +101,7 @@ const float DURATION = 0.3;
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     // Calculate animation progress with easing
     float baseProgress = clamp((iTime - iTimeCursorChange) / DURATION, 0.0, 1.0);
+    baseProgress = mix(1.0, baseProgress, float(iFocus)); // when unfocused iTime stops, force trail done
 
     vec2 uv = fragCoord / iResolution.xy;
     vec4 background = texture(iChannel0, uv);

--- a/public/shaders/cursor_smear_fade.glsl
+++ b/public/shaders/cursor_smear_fade.glsl
@@ -96,6 +96,7 @@ const float DURATION = 0.5;
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     // Calculate animation progress with easing
     float baseProgress = clamp((iTime - iTimeCursorChange) / DURATION, 0.0, 1.0);
+    baseProgress = mix(1.0, baseProgress, float(iFocus)); // when unfocused iTime stops, force trail done
 
     vec2 uv = fragCoord / iResolution.xy;
     vec4 background = texture(iChannel0, uv);

--- a/public/shaders/cursor_smear_gradient.glsl
+++ b/public/shaders/cursor_smear_gradient.glsl
@@ -115,6 +115,7 @@ const float DURATION = 0.25;
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     // Calculate animation progress with easing
     float baseProgress = clamp((iTime - iTimeCursorChange) / DURATION, 0.0, 1.0);
+    baseProgress = mix(1.0, baseProgress, float(iFocus)); // when unfocused iTime stops, force trail done
 
     vec2 uv = fragCoord / iResolution.xy;
     vec4 background = texture(iChannel0, uv);

--- a/public/shaders/cursor_smear_rainbow.glsl
+++ b/public/shaders/cursor_smear_rainbow.glsl
@@ -96,6 +96,7 @@ const float DURATION = 0.5;
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     // Calculate animation progress with easing
     float baseProgress = clamp((iTime - iTimeCursorChange) / DURATION, 0.0, 1.0);
+    baseProgress = mix(1.0, baseProgress, float(iFocus)); // when unfocused iTime stops, force trail done
 
     vec2 uv = fragCoord / iResolution.xy;
     vec4 background = texture(iChannel0, uv);


### PR DESCRIPTION
## Problem

When the window loses focus, `iTime` stops advancing. Any cursor trail animation in progress at that moment freezes at its current `progress` value — it never fades out. The smear stays visible until new output arrives and triggers a redraw.

![shader_sticking_fade_issue_screenshot.png](https://github.com/user-attachments/assets/89b6dcc4-5bee-4585-961b-f564e0782b0e)

The yellow trail is stuck on screen — the window was unfocused mid-animation and `iTime` stopped, so `progress` never reached 1.0 and the trail never faded.

## Fix

After computing `progress`, check `iFocus`. When the window is unfocused, force `progress` to `1.0` (animation complete) so the trail immediately fades to invisible:

```glsl
float progress = clamp((iTime - iTimeCursorChange) / DURATION, 0.0, 1.0);
progress = mix(1.0, progress, float(iFocus)); // when unfocused iTime stops, force trail done
```

`mix(1.0, progress, float(iFocus))` evaluates to `progress` when focused (no change) and `1.0` when unfocused (trail snaps to fully faded). The animation plays normally when the window is focused.

## Affected shaders

- `cursor_smear.glsl`
- `cursor_smear_fade.glsl`
- `cursor_smear_gradient.glsl`
- `cursor_smear_rainbow.glsl`
- `cursor_blaze.glsl`
- `cursor_blaze_tapered.glsl`

Note: `blaze_sparks.glsl`, `sparks.glsl`, and `party_sparks.glsl` use raw `elapsed` time with `iTime` baked into particle positions — fixing those requires a different approach and is out of scope here.

GTK4 linux wayland gnome